### PR TITLE
Allow skipping tests that require internet access

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile(
 			Test::Simple => 0,  # only needed for `make test'
                         YAML::XS => 0,
                         Net::DNS::Resolver::Mock => 0,
+                        Test::RequiresInternet => 0,
                         },
 	ABSTRACT_FROM  => 'lib/Mail/DKIM.pm', # retrieve abstract from module
 	AUTHOR         => 'Jason Long <jason@long.name>',

--- a/t/public_key.t
+++ b/t/public_key.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More tests => 5;
+use Test::RequiresInternet;
 
 use Mail::DKIM::Verifier;
 $Mail::DKIM::DNS::TIMEOUT = 3;


### PR DESCRIPTION
Test::RequiresInternet (which only depends on core Perl modules) skips
all tests in a file if the environment variable "NO_NETWORK_TESTING" is
set to a true value.

This allows installation (while still running tests) in build
environments with limited internet access.