### PR TITLE
ARC::Signer: Preserve leading fold from AR (if any) when copying to AAR.

### DIFF
--- a/lib/Mail/DKIM/ARC/Signer.pm
+++ b/lib/Mail/DKIM/ARC/Signer.pm
@@ -246,7 +246,7 @@ sub finish_header {
     foreach my $header ( @{ $self->{headers} } ) {
         $header =~ s/[\r\n]+$//;
         if ( $header =~ m/^Authentication-Results:/ ) {
-            my ( $arval ) = $header =~ m/^Authentication-Results:[^;]*;\s*(.*)/is;
+            my ( $arval ) = $header =~ m/^Authentication-Results:[^;]*;[\t ]*(.*)/is;
             my $parsed;
 	    eval {
 		$parsed= Mail::AuthenticationResults::Parser->new
@@ -263,11 +263,13 @@ sub finish_header {
               unless "\L$ardom" eq $self->{SrvId};   # make sure it's our domain
 
             $arval =~ s/;?\s*$//;    # ignore trailing semicolon and whitespace
+            # preserve leading fold if there is one, otherwise set one leading space
+            $arval =~ s/^\s*/ / unless ($arval =~ m/^\015\012/);
             if ($ar) {
-                $ar .= "; $arval";
+                $ar .= ";$arval";
             }
             else {
-                $ar = "$ardom; $arval";
+                $ar = "$ardom;$arval";
             }
 
             # get chain value from A-R header


### PR DESCRIPTION
Currently ARC::Signer with Chain => ar will take this AR header:
```
Authentication-Results: example.org; 
  arc=fail (bad something);
  spf=pass smtp.mailfrom="jason\@example.net";
```
And produce this AAR header:
```
ARC-Authentication-Results: i=1; example.org; arc=fail (bad something);
  spf=pass smtp.mailfrom="jason@example.net"
```

This change causes ARC::Signer to copy the first fold from the AR header in to the AAR header as well, so the result is:
```
ARC-Authentication-Results: i=1; example.org;
  arc=fail (bad something);
  spf=pass smtp.mailfrom="jason@example.net"
```

This change is purely cosmetic, but I do find it very convenient to have all of the auth results indented the same. It makes it easier to read at a glance. It also seems pretty standard to fold after the authserv-id, as Mail::AuthenticationResults does, and Google seems to do for both AR and AAR headers.
