### PR TITLE
Fix typo in ARC signer example code.

### DIFF
--- a/lib/Mail/DKIM/ARC/Signer.pm
+++ b/lib/Mail/DKIM/ARC/Signer.pm
@@ -51,7 +51,7 @@ use Mail::AuthenticationResults::Header::AuthServID;
   }
   $signer->CLOSE;
 
-  die 'Failed' $signer->result_details() unless $signer->result() eq 'sealed';
+  die 'Failed' $signer->result_detail() unless $signer->result() eq 'sealed';
 
   # Get all the signature headers to prepend to the message
   # ARC-Seal, ARC-Message-Signature and ARC-Authentication-Results


### PR DESCRIPTION
This is a tiny thing, but apparently I copied this code and I just discovered the issue with it some 2 years later! So here's a patch to perhaps save some others from a little surprise down the road :)
