### PR TITLE
Remove the explicit version check for Net::DNS

### DIFF
--- a/lib/Mail/DKIM/Policy.pm
+++ b/lib/Mail/DKIM/Policy.pm
@@ -71,7 +71,7 @@ sub fetch_async {
             next unless $rr->type eq 'TXT';
 
             # join with no intervening spaces, RFC 5617
-            if ( Net::DNS->VERSION >= 0.69 ) {
+            if ( $rr->can('txtdata') ) {
 
                 # must call txtdata() in a list context
                 $strn = join '', $rr->txtdata;

--- a/lib/Mail/DKIM/PublicKey.pm
+++ b/lib/Mail/DKIM/PublicKey.pm
@@ -104,7 +104,7 @@ sub fetch_async {
             next unless $rr->type eq 'TXT';
 
             # join with no intervening spaces, RFC 6376
-            if ( Net::DNS->VERSION >= 0.69 ) {
+            if ( $rr->can('txtdata') ) {
 
                 # must call txtdata() in a list context
                 $strn = join '', $rr->txtdata;

--- a/t/signer_expiration.t
+++ b/t/signer_expiration.t
@@ -101,7 +101,7 @@ sub Mail::DKIM::DNS::fake_query {
             foreach my $rr (@result) {
 
                 # join with no intervening spaces, RFC 6376
-                if ( Net::DNS->VERSION >= 0.69 ) {
+                if ( $rr->can('txtdata') ) {
 
                     # must call txtdata() in a list context
                     printf STDERR ( "%s\n", join( "", $rr->txtdata ) );

--- a/t/verifier.t
+++ b/t/verifier.t
@@ -229,7 +229,7 @@ sub Mail::DKIM::DNS::fake_query {
             foreach my $rr (@result) {
 
                 # join with no intervening spaces, RFC 6376
-                if ( Net::DNS->VERSION >= 0.69 ) {
+                if ( $rr->can('txtdata') ) {
 
                     # must call txtdata() in a list context
                     printf STDERR ( "%s\n", join( "", $rr->txtdata ) );

--- a/t/verifier_strict.t
+++ b/t/verifier_strict.t
@@ -73,7 +73,7 @@ sub Mail::DKIM::DNS::fake_query {
             foreach my $rr (@result) {
 
                 # join with no intervening spaces, RFC 6376
-                if ( Net::DNS->VERSION >= 0.69 ) {
+                if ( $rr->can('txtdata') ) {
 
                     # must call txtdata() in a list context
                     printf STDERR ( "%s\n", join( "", $rr->txtdata ) );


### PR DESCRIPTION
Instead, check to see if the object can use the 'new' txtdata method, if so use it, and if not fallback to the legacy method.