### PR TITLE
Option to set a validate time when calling the validator

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ This file summarizes what's changed between releases of Mail-DKIM.
 {{$NEXT}}
   * Add missing Author prerequisite
     Thanks to Giovanni <g.bechis@snb.it>
+  * Option to pass a time to the Validator to assert the time
+    which should be considered as "now" for expiry checks
 
 1.20240619 2024-06-19 Australia/Melbourne
   * Remove version check for Net::DNS, this fixes issues when using a

--- a/lib/Mail/DKIM/ARC/Verifier.pm
+++ b/lib/Mail/DKIM/ARC/Verifier.pm
@@ -193,6 +193,11 @@ sub add_signature {
 
     return if $self->{result};    # already failed
 
+    # Set verification time if we have one
+    if ($self->{verify_time}) {
+        $signature->{_verify_time} = $self->{verify_time};
+    }
+
     push @{ $self->{signatures} }, $signature;
 
     unless ( $self->check_signature($signature) ) {

--- a/lib/Mail/DKIM/ARC/Verifier.pm
+++ b/lib/Mail/DKIM/ARC/Verifier.pm
@@ -195,7 +195,7 @@ sub add_signature {
 
     # Set verification time if we have one
     if ($self->{verify_time}) {
-        $signature->{_verify_time} = $self->{verify_time};
+        $signature->set_verify_time($self->{verify_time});
     }
 
     push @{ $self->{signatures} }, $signature;

--- a/lib/Mail/DKIM/Signature.pm
+++ b/lib/Mail/DKIM/Signature.pm
@@ -301,6 +301,11 @@ sub check_canonicalization {
     return 1;
 }
 
+sub set_verify_time {
+    my ( $self, $verify_time ) = @_;
+    $self->{_verify_time} = $verify_time;
+}
+
 # checks whether the expiration time on this signature is acceptable
 # returns a true value if acceptable, false otherwise
 #

--- a/lib/Mail/DKIM/Signature.pm
+++ b/lib/Mail/DKIM/Signature.pm
@@ -308,7 +308,6 @@ sub check_expiration {
     my $self = shift;
     my $x    = $self->expiration;
     return 1 if not defined $x;
-
     $self->{_verify_time} ||= time();
     return ( $self->{_verify_time} <= $x );
 }

--- a/lib/Mail/DKIM/Verifier.pm
+++ b/lib/Mail/DKIM/Verifier.pm
@@ -191,6 +191,11 @@ sub add_signature {
     croak 'wrong number of arguments' unless ( @_ == 1 );
     my ($signature) = @_;
 
+    # Set verification time if we have one
+    if ($self->{verify_time}) {
+        $signature->{_verify_time} = $self->{verify_time};
+    }
+
     # ignore signature headers once we've seen 50 or so
     # this protects against abuse.
     return if ( @{ $self->{signatures} } > $MAX_SIGNATURES_TO_PROCESS );

--- a/lib/Mail/DKIM/Verifier.pm
+++ b/lib/Mail/DKIM/Verifier.pm
@@ -193,7 +193,7 @@ sub add_signature {
 
     # Set verification time if we have one
     if ($self->{verify_time}) {
-        $signature->{_verify_time} = $self->{verify_time};
+        $signature->set_verify_time($self->{verify_time});
     }
 
     # ignore signature headers once we've seen 50 or so

--- a/t/signer_expiration_set_time.t
+++ b/t/signer_expiration_set_time.t
@@ -1,0 +1,145 @@
+#!/usr/bin/perl -I../lib
+
+use strict;
+use warnings;
+use Test::Simple tests => 6;
+use Test::More;
+
+use Mail::DKIM::Signer;
+use Mail::DKIM::Verifier;
+
+my $homedir = ( -d "t" ) ? "t" : ".";
+
+my $tdir    = -f "t/test.key" ? "t" : ".";
+my $keyfile = "$tdir/test.key";
+
+sub generate_signed_email {
+  my ($timestamp,$expiration) = @_;
+
+  my $dkim    = Mail::DKIM::Signer->new(
+    Algorithm  => "rsa-sha256",
+    Method     => "relaxed",
+    Domain     => "example.org",
+    Selector   => "expirationtest",
+    KeyFile    => $keyfile,
+    Timestamp  => $timestamp,
+    Expiration => $expiration,
+  );
+  ok( $dkim, "new() works" );
+
+  my $sample_email = <<END_OF_SAMPLE;
+From: jason <jason\@example.org>
+Subject: hi there
+Comment: what is a comment
+
+this is a sample message
+END_OF_SAMPLE
+  $sample_email =~ s/\n/\015\012/gs;
+
+  $dkim->PRINT($sample_email);
+  $dkim->CLOSE;
+
+  my $signature = $dkim->signature;
+  ok( $signature, "signature() works" );
+
+  print "# signature=" . $signature->as_string . "\n";
+  ok( $signature->as_string =~ / t=$timestamp; /, "got expected signature timestamp value" );
+  ok( $signature->as_string =~ / x=$expiration; /, "got expected signature expiration value" );
+
+  my $signed_email = $signature->as_string . "\r\n" . $sample_email;
+  return $signed_email;
+}
+
+my $timestamp = time;
+my $expiration = $timestamp + 3600;
+my $signed_email = generate_signed_email($timestamp,$expiration);
+my $verifier = Mail::DKIM::Verifier->new();
+$verifier->{verify_time} = $timestamp + 86400;
+$verifier->PRINT($signed_email);
+$verifier->CLOSE;
+isnt( $verifier->result, 'pass', 'Expired Signature does not pass');
+
+$verifier = Mail::DKIM::Verifier->new();
+$verifier->PRINT($signed_email);
+$verifier->CLOSE;
+is( $verifier->result, 'pass', 'Non-expired Signature does pass');
+
+# override the DNS implementation, so that these tests do not
+# rely on DNS servers I have no control over
+my $CACHE;
+
+sub Mail::DKIM::DNS::fake_query {
+    my ( $domain, $type ) = @_;
+    die "can't lookup $type record" if $type ne "TXT";
+
+    unless ($CACHE) {
+        open my $fh, "<", "$homedir/FAKE_DNS.dat"
+          or die "Error: cannot read $homedir/FAKE_DNS.dat: $!\n";
+        $CACHE = {};
+        while (<$fh>) {
+            chomp;
+            next if /^\s*[#;]/ || /^\s*$/;
+            my ( $k, $v ) = split /\s+/, $_, 2;
+            $CACHE->{$k} =
+                ( $v =~ /^~~(.*)~~$/ ) ? "$1"
+              : $v eq "NXDOMAIN"       ? []
+              :                          [ bless \$v, "FakeDNS::Record" ];
+        }
+        close $fh;
+    }
+
+    if ( not exists $CACHE->{$domain} ) {
+        warn "did not cache that DNS entry: $domain\n";
+        print STDERR ">>>\n";
+        my @result = Mail::DKIM::DNS::orig_query( $domain, $type );
+        if ( !@result ) {
+            print STDERR "No results: $@\n";
+        }
+        else {
+            foreach my $rr (@result) {
+
+                # join with no intervening spaces, RFC 6376
+                if ( $rr->can('txtdata') ) {
+
+                    # must call txtdata() in a list context
+                    printf STDERR ( "%s\n", join( "", $rr->txtdata ) );
+                }
+                else {
+                    # char_str_list method is 'historical'
+                    printf STDERR ( "%s\n", join( "", $rr->char_str_list ) );
+                }
+            }
+        }
+        print STDERR "<<<\n";
+        die;
+    }
+
+    if ( ref $CACHE->{$domain} ) {
+        return @{ $CACHE->{$domain} };
+    }
+    else {
+        die "DNS error: $CACHE->{$domain}\n";
+    }
+}
+
+BEGIN {
+    unless ( $ENV{use_real_dns} ) {
+        *Mail::DKIM::DNS::orig_query = *Mail::DKIM::DNS::query;
+        *Mail::DKIM::DNS::query      = *Mail::DKIM::DNS::fake_query;
+    }
+}
+
+package FakeDNS::Record;
+
+sub type {
+    return "TXT";
+}
+
+sub char_str_list {
+    return ${ $_[0] };
+}
+
+sub txtdata {
+    return ${ $_[0] };
+}
+


### PR DESCRIPTION
Option to pass a "now" time to the verifiers, so we can check how a signature would have validated at a given timestamp.