### PR TITLE
Tad 55 ed25519 test fails with cryptx 0081

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 This file summarizes what's changed between releases of Mail-DKIM.
 
 {{$NEXT}}
+  * Fix loading of ED25519 keys with CryptX-0.081
 
 1.20240827 2024-08-27 Australia/Melbourne
   * Add missing Author prerequisite

--- a/lib/Mail/DKIM/PrivateKey.pm
+++ b/lib/Mail/DKIM/PrivateKey.pm
@@ -140,10 +140,10 @@ sub _convert_ed25519 {
         $cork = new Crypt::PK::Ed25519;
 
         # Prepend/append with PEM boilerplate
-        my $pem = "-----BEGIN ED25519 PRIVATE KEY-----\n";
+        my $pem = "-----BEGIN PRIVATE KEY-----\n";
         $pem .= $self->data;
         $pem .= "\n";
-        $pem .= "-----END ED25519 PRIVATE KEY-----\n";
+        $pem .= "-----END PRIVATE KEY-----\n";
 
         # Pass PEM text buffer
         $cork->import_key(\$pem)


### PR DESCRIPTION
    Fix loading of ed25519 keys
    
    CryptX-0.081 has the following in the changelog
    
    * BIG CHANGE switch to PEM/SSH key loading via libtomcrypt
    
    This change caused Mail::DKIM to fail to load ED25519 private keys,
    resulting in test failures and failure to sign with those keys.
    
    This change fixes the loading of those keys, and is confirmed to
    also work with CryptX-0.080
